### PR TITLE
Fixed problem with template not actually appearing in Processing Modes drop-down when built and installed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Instructions
 ------------
 * Set properties in build.xml
     * The name of your mode (lib.name) must end in "Mode" (e.g. MyFancyMode) otherwise it won't work.
+    * Your Mode subclass must also have the same name as lib.name, as well as the project name for build.xml.
     * Set the path to your processing jars (core.jar, pde.jar)
     * If you want to automatically install your mode (target: install ), set the path to your modes folder (typically a folder named "modes" inside your sketchbook folder)
     * If you want to run processing after building (target: run), set the path to your processing executable.

--- a/build.xml
+++ b/build.xml
@@ -3,10 +3,11 @@
     <description>Template for extending Java Mode in Processing 2.0</description>
 
     <!-- name of your mode package (will be used as dir name) -->
-    <property name="lib.name" 	value="Mode Template" />
+	<!-- note, this must be the same name as your mode subclass, AND the same name as this build project. -->
+    <property name="lib.name" 	value="TemplateMode" />
 
     <!-- version -->
-    <property name="release" 	value="0.1" />
+    <property name="release"	value="0.1" />
 
     <!-- java version -->
     <property name="java.target.version" value="1.6" />


### PR DESCRIPTION
Current template when built and installed was not actually showing up in Processing Modes drop-down. Found out (after much hair-tearing) that this is because lib.name in build.xml was not the same value as the subclass of JavaMode.

Fixed this problem, and updated the readme to help other people who run into this problem. 

Tested in Processing 2.0.3.
